### PR TITLE
Fix code scanning alert - #1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5
         with:
           bun-version: latest
 


### PR DESCRIPTION
Fix code scanning alert - Unpinned tag for a non-immutable Action in workflow 

fixes #3 